### PR TITLE
Basic Yul compiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,6 +422,11 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "stringreader"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "syn"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,6 +447,14 @@ dependencies = [
 [[package]]
 name = "tiny-keccak"
 version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -492,6 +505,8 @@ version = "0.1.0"
 dependencies = [
  "ethabi 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stringreader 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vyper-parser 0.1.0",
  "yultsur 0.1.0 (git+https://github.com/g-r-a-n-t/yultsur)",
 ]
@@ -695,9 +710,11 @@ source = "git+https://github.com/g-r-a-n-t/yultsur#db1336ac92b85ae6d07af63918e0b
 "checksum serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)" = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+"checksum stringreader 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "913e7b03d63752f6cdd2df77da36749d82669904798fe8944b9ec3d23f159905"
 "checksum syn 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ddc157159e2a7df58cd67b1cace10b8ed256a404fb0070593f137d8ba6bef4de"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
+"checksum tiny-keccak 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2953ca5148619bc99695c1274cb54c5275bbb913c6adad87e72eaf8db9787f69"
 "checksum uint 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e75a4cdd7b87b28840dba13c483b9a88ee6bbf16ba5c951ee1ecfcf723078e0d"
 "checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,11 @@ version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "base64"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,14 +32,32 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bitvec"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bumpalo"
 version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byte-slice-cast"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "c2-chacha"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cfg-if"
@@ -51,9 +74,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ethabi"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ethereum-types 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uint 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixed-hash 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-rlp 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ethbloom 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixed-hash 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-rlp 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uint 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "futures"
@@ -61,11 +138,58 @@ version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "getrandom"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hex"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "impl-codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rlp 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -84,6 +208,11 @@ dependencies = [
 [[package]]
 name = "lazy_static"
 version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -106,6 +235,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-slice-cast 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "primitive-types"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fixed-hash 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-codec 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-rlp 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-serde 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uint 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -141,6 +298,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +351,14 @@ version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rlp"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ron"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,6 +367,11 @@ dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ryu"
@@ -210,6 +417,11 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "syn"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +437,25 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "uint"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -251,7 +482,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "vyper"
 version = "0.1.0"
 dependencies = [
+ "vyper-compiler 0.1.0",
  "vyper-parser 0.1.0",
+]
+
+[[package]]
+name = "vyper-compiler"
+version = "0.1.0"
+dependencies = [
+ "ethabi 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vyper-parser 0.1.0",
+ "yultsur 0.1.0 (git+https://github.com/g-r-a-n-t/yultsur)",
 ]
 
 [[package]]
@@ -266,6 +508,11 @@ dependencies = [
  "wasm-bindgen 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-test 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wasm-bindgen"
@@ -386,43 +633,77 @@ dependencies = [
  "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "yultsur"
+version = "0.1.0"
+source = "git+https://github.com/g-r-a-n-t/yultsur#db1336ac92b85ae6d07af63918e0bfb1afb71f4a"
+
 [metadata]
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
+"checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+"checksum bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a993f74b4c99c1908d156b8d2e0fb6277736b0ecbd833982fd1241d39b2766a6"
 "checksum bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad807f2fc2bf185eeb98ff3a901bd46dc5ad58163d0fa4577ba0d25674d71708"
+"checksum byte-slice-cast 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
+"checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
+"checksum crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+"checksum ethabi 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97652a7d1f2504d6c885c87e242a06ccef5bd3054093d3fb742d8fb64806231a"
+"checksum ethbloom 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "32cfe1c169414b709cf28aa30c74060bdb830a03a8ba473314d079ac79d80a5f"
+"checksum ethereum-types 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba744248e3553a393143d5ebb68939fc3a4ec0c22a269682535f5ffe7fed728c"
+"checksum fixed-hash 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3367952ceb191f4ab95dd5685dc163ac539e36202f9fcfd0cb22f9f9c542fefc"
 "checksum futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
+"checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+"checksum hex 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "76cdda6bf525062a0c9e8f14ee2b37935c86b8efb6c8b69b3c83dfb518a914af"
+"checksum impl-codec 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1be51a921b067b0eaca2fad532d9400041561aa922221cc65f95a85641c6bf53"
+"checksum impl-rlp 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8f7a72f11830b52333f36e3b09a288333888bf54380fd0ac0790a3c31ab0f3c5"
+"checksum impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "58e3cae7e99c7ff5a995da2cf78dd0a5383740eda71d98cf7b1910c301ac69b8"
+"checksum impl-serde 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5bbe9ea9b182f0fb1cabbd61f4ff9b7b7b9197955e95a7e4c27de5055eb29ff8"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum js-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)" = "367647c532db6f1555d7151e619540ec5f713328235b8c062c6b4f63e84adfe3"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+"checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+"checksum parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f747c06d9f3b2ad387ac881b9667298c81b1243aa9833f086e05996937c35507"
+"checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+"checksum primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e4336f4f5d5524fa60bcbd6fe626f9223d8142a50e7053e979acdf0da41ab975"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0319972dcae462681daf4da1adeeaa066e3ebd29c69be96c6abb1259d2ee2bcc"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+"checksum rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+"checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
+"checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+"checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
+"checksum rlp 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3a44d5ae8afcb238af8b75640907edc6c931efcfab2c854e81ed35fa080f84cd"
 "checksum ron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2ece421e0c4129b90e4a35b6f625e472e96c552136f5093a2f4fa2bbb75a62d5"
+"checksum rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 "checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
 "checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 "checksum serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)" = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
+"checksum static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 "checksum syn 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ddc157159e2a7df58cd67b1cace10b8ed256a404fb0070593f137d8ba6bef4de"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
+"checksum uint 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e75a4cdd7b87b28840dba13c483b9a88ee6bbf16ba5c951ee1ecfcf723078e0d"
 "checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 "checksum wasm-bindgen 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)" = "99de4b68939a880d530aed51289a7c7baee154e3ea8ac234b542c49da7134aaf"
 "checksum wasm-bindgen-backend 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)" = "b58e66a093a7b7571cb76409763c495b8741ac4319ac20acc2b798f6766d92ee"
 "checksum wasm-bindgen-futures 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)" = "83420b37346c311b9ed822af41ec2e82839bfe99867ec6c54e2da43b7538771c"
@@ -434,3 +715,4 @@ dependencies = [
 "checksum wasm-bindgen-webidl 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)" = "f85a3825a459cf6a929d03bacb54dca37a614d43032ad1343ef2d4822972947d"
 "checksum web-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)" = "2fb60433d0dc12c803b9b017b3902d80c9451bab78d27bc3210bf2a7b96593f1"
 "checksum weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164"
+"checksum yultsur 0.1.0 (git+https://github.com/g-r-a-n-t/yultsur)" = "<none>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ categories = ["cryptography::cryptocurrencies", "command-line-utilities", "devel
 readme = "README.md"
 
 [workspace]
-members = [".", "parser"]
+members = [".", "parser", "compiler"]
 
 [dependencies]
 vyper-parser = {path = "parser", version = "0.1.0"}
+vyper-compiler = {path = "compiler", version = "0.1.0"}

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "vyper-compiler"
+version = "0.1.0"
+authors = ["Grant Wuerker <gwuerker@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+vyper-parser = {path = "../parser", version = "0.1.0"}
+hex = "0.4"
+yultsur = { git = "https://github.com/g-r-a-n-t/yultsur" }
+ethabi = "11.0"

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -11,3 +11,5 @@ vyper-parser = {path = "../parser", version = "0.1.0"}
 hex = "0.4"
 yultsur = { git = "https://github.com/g-r-a-n-t/yultsur" }
 ethabi = "11.0"
+tiny-keccak = { version = "2.0", features = ["keccak"] }
+stringreader = "0.1"

--- a/compiler/src/errors.rs
+++ b/compiler/src/errors.rs
@@ -1,0 +1,43 @@
+use vyper_parser::errors::ParseError;
+use vyper_parser::tokenizer::TokenizeError;
+
+#[derive(Debug)]
+pub enum ErrorKind {
+    StaticStr(&'static str),
+    Str(String),
+}
+
+#[derive(Debug)]
+pub struct CompileError {
+    errors: Vec<ErrorKind>,
+}
+
+impl CompileError {
+    pub fn new() -> Self {
+        Self { errors: Vec::new() }
+    }
+
+    pub fn static_str(s: &'static str) -> Self {
+        Self {
+            errors: vec![ErrorKind::StaticStr(s)],
+        }
+    }
+
+    pub fn str(s: String) -> Self {
+        Self {
+            errors: vec![ErrorKind::Str(s)],
+        }
+    }
+}
+
+impl<'a> From<ParseError<'a>> for CompileError {
+    fn from(_: ParseError<'a>) -> Self {
+        CompileError::static_str("Parser error")
+    }
+}
+
+impl<'a> From<TokenizeError> for CompileError {
+    fn from(_: TokenizeError) -> Self {
+        CompileError::static_str("Tokenize error")
+    }
+}

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod errors;
+pub mod yul;

--- a/compiler/src/yul/ast_builder.rs
+++ b/compiler/src/yul/ast_builder.rs
@@ -1,0 +1,330 @@
+use crate::errors::CompileError;
+use crate::yul::{base, constructor, selectors};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+use vyper_parser::ast as vyp;
+use yultsur::yul;
+
+type Shared<T> = Rc<RefCell<T>>;
+
+#[allow(dead_code)]
+struct ModuleScope<'a> {
+    type_defs: HashMap<&'a str, &'a vyp::TypeDesc<'a>>,
+}
+
+#[allow(dead_code)]
+struct ContractScope<'a> {
+    parent: Shared<ModuleScope<'a>>,
+}
+
+#[allow(dead_code)]
+struct FunctionScope<'a> {
+    parent: Shared<ContractScope<'a>>,
+}
+
+#[allow(dead_code)]
+enum Scope<'a> {
+    Module(Shared<ModuleScope<'a>>),
+}
+
+impl<'a> ModuleScope<'a> {
+    fn new() -> Shared<Self> {
+        Rc::new(RefCell::new(ModuleScope {
+            type_defs: HashMap::new(),
+        }))
+    }
+}
+
+impl<'a> ContractScope<'a> {
+    fn new(parent: Shared<ModuleScope<'a>>) -> Shared<Self> {
+        Rc::new(RefCell::new(ContractScope { parent }))
+    }
+}
+
+impl<'a> FunctionScope<'a> {
+    fn new(parent: Shared<ContractScope<'a>>) -> Shared<Self> {
+        Rc::new(RefCell::new(FunctionScope { parent }))
+    }
+}
+
+pub fn module<'a>(module: &'a vyp::Module<'a>) -> Result<yul::Object, CompileError> {
+    let scope = ModuleScope::new();
+
+    let mut statements = module
+        .body
+        .iter()
+        .map(|stmt| module_stmt(Rc::clone(&scope), &stmt.node))
+        .collect::<Result<Vec<Option<yul::Statement>>, CompileError>>()?
+        .into_iter()
+        .filter_map(|statement| statement)
+        .collect::<Vec<yul::Statement>>();
+
+    // TODO: Handle multiple objects(contracts)
+    if let Some(yul::Statement::Object(object)) = statements.pop() {
+        return Ok(object);
+    }
+
+    Err(CompileError::static_str(
+        "Final statement in Yul module is not an object.",
+    ))
+}
+
+fn module_stmt<'a>(
+    scope: Shared<ModuleScope<'a>>,
+    stmt: &'a vyp::ModuleStmt<'a>,
+) -> Result<Option<yul::Statement>, CompileError> {
+    match stmt {
+        vyp::ModuleStmt::TypeDef { .. } => {
+            type_def(scope, stmt)?;
+            Ok(None)
+        }
+        vyp::ModuleStmt::ContractDef { .. } => contract_def(scope, stmt).map(|s| Some(s)),
+        _ => Err(CompileError::static_str(
+            "Unable to translate module statement.",
+        )),
+    }
+}
+
+fn contract_def<'a>(
+    scope: Shared<ModuleScope<'a>>,
+    stmt: &'a vyp::ModuleStmt<'a>,
+) -> Result<yul::Statement, CompileError> {
+    let new_scope = ContractScope::new(scope);
+
+    if let vyp::ModuleStmt::ContractDef { name: _, body } = stmt {
+        let mut statements = body
+            .iter()
+            .map(|stmt| contract_stmt(Rc::clone(&new_scope), &stmt.node))
+            .collect::<Result<Vec<yul::Statement>, CompileError>>()?;
+
+        // TODO: Use functions from actual contract ABI once the builder is merged.
+        statements.push(yul::Statement::Switch(selectors::switch(&vec![])?));
+
+        let def = yul::Object {
+            name: base::untyped_identifier("Contract"),
+            code: constructor::code(),
+            objects: vec![yul::Object {
+                name: base::untyped_identifier("runtime"),
+                code: yul::Code {
+                    block: yul::Block { statements },
+                },
+                objects: vec![],
+            }],
+        };
+
+        return Ok(yul::Statement::Object(def));
+    }
+
+    Err(CompileError::static_str(
+        "Contract definition translation requires ContractDef.",
+    ))
+}
+
+fn contract_stmt<'a>(
+    scope: Shared<ContractScope<'a>>,
+    stmt: &'a vyp::ContractStmt<'a>,
+) -> Result<yul::Statement, CompileError> {
+    match stmt {
+        vyp::ContractStmt::FuncDef { .. } => func_def(scope, stmt),
+        _ => Err(CompileError::static_str(
+            "Unable to translate module statement.",
+        )),
+    }
+}
+
+fn type_def<'a>(
+    scope: Shared<ModuleScope<'a>>,
+    stmt: &'a vyp::ModuleStmt<'a>,
+) -> Result<(), CompileError> {
+    if let vyp::ModuleStmt::TypeDef { name, typ } = stmt {
+        scope.borrow_mut().type_defs.insert(name.node, &typ.node);
+        return Ok(());
+    }
+
+    Err(CompileError::static_str(
+        "Type definition translation requires TypeDef.",
+    ))
+}
+
+fn func_def<'a>(
+    scope: Shared<ContractScope<'a>>,
+    stmt: &'a vyp::ContractStmt<'a>,
+) -> Result<yul::Statement, CompileError> {
+    if let vyp::ContractStmt::FuncDef {
+        qual: _,
+        name,
+        args,
+        return_type,
+        body,
+    } = stmt
+    {
+        let new_scope = FunctionScope::new(scope);
+
+        let parameters = args
+            .iter()
+            .map(|arg| func_def_arg(Rc::clone(&new_scope), &arg.node))
+            .collect::<Result<Vec<yul::Identifier>, CompileError>>()?;
+
+        let returns = if return_type.is_some() {
+            vec![base::untyped_identifier("return_value")]
+        } else {
+            Vec::new()
+        };
+
+        let statements: Vec<yul::Statement> = body
+            .iter()
+            .map(|stmt| func_stmt(Rc::clone(&new_scope), &stmt.node))
+            .collect::<Result<Vec<yul::Statement>, CompileError>>()?;
+
+        return Ok(yul::Statement::FunctionDefinition(
+            yul::FunctionDefinition {
+                name: base::untyped_identifier(name.node),
+                parameters,
+                returns,
+                block: yul::Block { statements },
+            },
+        ));
+    }
+
+    Err(CompileError::static_str(
+        "Function definition translation requires FuncDef.",
+    ))
+}
+
+fn func_def_arg<'a>(
+    _scope: Shared<FunctionScope<'a>>,
+    arg: &'a vyp::FuncDefArg<'a>,
+) -> Result<yul::Identifier, CompileError> {
+    Ok(base::untyped_identifier(arg.name.node))
+}
+
+fn func_stmt<'a>(
+    scope: Shared<FunctionScope<'a>>,
+    stmt: &'a vyp::FuncStmt<'a>,
+) -> Result<yul::Statement, CompileError> {
+    match stmt {
+        vyp::FuncStmt::Return { .. } => func_return(scope, stmt),
+        _ => Err(CompileError::static_str(
+            "Unable to translate function statement",
+        )),
+    }
+}
+
+fn func_return<'a>(
+    scope: Shared<FunctionScope<'a>>,
+    stmt: &'a vyp::FuncStmt<'a>,
+) -> Result<yul::Statement, CompileError> {
+    if let vyp::FuncStmt::Return { value: Some(value) } = stmt {
+        let return_value = expr(scope, &value.node)?;
+
+        return Ok(yul::Statement::Assignment(yul::Assignment {
+            identifiers: vec![base::untyped_identifier("return_val")],
+            expression: return_value,
+        }));
+    }
+
+    Err(CompileError::static_str(
+        "Function return translation requires Return parameter.",
+    ))
+}
+
+fn expr<'a>(
+    _scope: Shared<FunctionScope<'a>>,
+    expr: &'a vyp::Expr<'a>,
+) -> Result<yul::Expression, CompileError> {
+    match expr {
+        vyp::Expr::Name(name) => Ok(base::untyped_literal_expr(name)),
+        _ => Err(CompileError::static_str("Unable to translate expression")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    /*
+    #[test]
+    fn test_compile_type_def() {
+        let toks = vyper_parser::get_parse_tokens("type Num = u256").unwrap();
+        let stmt = parsers::type_def(&toks[..]).unwrap().1.node;
+
+        let mut scope = ModuleScope::new();
+
+        // Expecting the type definition to exist within new_scope.
+        // There is no resulting statement from compiling a TypeDef.
+        type_def(Rc::clone(&scope), &stmt);
+
+        assert_eq!(
+            scope.borrow().type_defs["Num"],
+            &TypeDesc::Base { base: "u256" },
+            "Compilation of type definition failed."
+        );
+    }
+
+    #[test]
+    fn test_compile_func_def() {
+        let toks =
+            vyper_parser::get_parse_tokens("def double(x: u256) -> u256:\n   return x").unwrap();
+        let stmt = parsers::func_def(&toks[..]).unwrap().1.node;
+
+        let mut scope = ContractScope::new(ModuleScope::new());
+
+        if let Ok(Some(statement)) = func_def(Rc::clone(&scope), &stmt) {
+            assert_eq!(
+                statement.to_string(),
+                "function double(x:u256) -> return_val { return_val := x }",
+                "Compilation of function definition failed."
+            );
+        } else {
+            assert!(false, "Unexpected error.");
+        }
+    }
+
+    #[test]
+    fn test_contract_def() {
+        let vyp_code = "contract Foo:\
+                        \n  pub def bar(x: u256) -> u256:\
+                        \n    return x";
+        let toks = vyper_parser::get_parse_tokens(vyp_code).unwrap();
+        let stmt = parsers::contract_def(&toks[..]).unwrap().1.node;
+
+        let mut scope = ModuleScope::new().into_shared();
+
+        if let Ok(Some(statement)) = contract_def(scope, &stmt) {
+            assert_eq!(
+                statement.to_string(),
+                "object \"Foo\" { function bar(x:u256) -> return_val { return_val := x } }",
+                "Compilation of contract definition failed."
+            );
+        } else {
+            assert!(false, "Unexpected error.");
+        }
+    }
+
+    #[test]
+    fn test_custom_type_in_function() {
+        let vyp_code = "pub def bar(x: CustomType) -> CustomType:\
+                        \n  return x";
+        let toks = vyper_parser::get_parse_tokens(vyp_code).unwrap();
+        let stmt = parsers::func_def(&toks[..]).unwrap().1.node;
+
+        let mut module_scope = ModuleScope::new().into_shared();
+        let u256 = TypeDesc::Base { base: "u256" };
+        module_scope
+            .borrow_mut()
+            .type_defs
+            .insert("CustomType", &u256);
+        let scope = ContractScope::new(module_scope).into_shared();
+
+        if let Ok(Some(statement)) = func_def(scope, &stmt) {
+            assert_eq!(
+                statement.to_string(),
+                "function bar(x:u256) -> return_val { return_val := x }",
+                "Compilation of module definition failed."
+            );
+        } else {
+            assert!(false, "Unexpected error.");
+        }
+    }
+    */
+}

--- a/compiler/src/yul/ast_builder.rs
+++ b/compiler/src/yul/ast_builder.rs
@@ -99,7 +99,7 @@ fn contract_def<'a>(
             .collect::<Result<Vec<yul::Statement>, CompileError>>()?;
 
         // TODO: Use functions from actual contract ABI once the builder is merged.
-        statements.push(yul::Statement::Switch(selectors::switch(&vec![])?));
+        statements.push(yul::Statement::Switch(selectors::switch(vec![])?));
 
         let def = yul::Object {
             name: base::untyped_identifier("Contract"),

--- a/compiler/src/yul/base.rs
+++ b/compiler/src/yul/base.rs
@@ -1,0 +1,23 @@
+use yultsur::yul;
+
+pub fn untyped_identifier_expr(i: &str) -> yul::Expression {
+    yul::Expression::Identifier(untyped_identifier(i))
+}
+
+pub fn untyped_identifier(i: &str) -> yul::Identifier {
+    yul::Identifier {
+        identifier: String::from(i),
+        yultype: None,
+    }
+}
+
+pub fn untyped_literal_expr(l: &str) -> yul::Expression {
+    yul::Expression::Literal(untyped_literal(l))
+}
+
+pub fn untyped_literal(l: &str) -> yul::Literal {
+    yul::Literal {
+        literal: String::from(l),
+        yultype: None,
+    }
+}

--- a/compiler/src/yul/constructor.rs
+++ b/compiler/src/yul/constructor.rs
@@ -1,0 +1,46 @@
+use crate::yul::base;
+use yultsur::yul;
+
+/// Builds the code block that returns the runtime object.
+pub fn code() -> yul::Code {
+    yul::Code {
+        block: yul::Block {
+            statements: vec![
+                yul::Statement::VariableDeclaration(yul::VariableDeclaration {
+                    identifiers: vec![base::untyped_identifier("size")],
+                    expression: Some(yul::Expression::FunctionCall(yul::FunctionCall {
+                        identifier: base::untyped_identifier("datasize"),
+                        arguments: vec![base::untyped_identifier_expr(r#""runtime""#)],
+                    })),
+                }),
+                yul::Statement::Expression(yul::Expression::FunctionCall(yul::FunctionCall {
+                    identifier: base::untyped_identifier("datacopy"),
+                    arguments: vec![
+                        base::untyped_literal_expr("0"),
+                        yul::Expression::FunctionCall(yul::FunctionCall {
+                            identifier: base::untyped_identifier("dataoffset"),
+                            arguments: vec![base::untyped_literal_expr(r#""runtime""#)],
+                        }),
+                        base::untyped_identifier_expr("size"),
+                    ],
+                })),
+                yul::Statement::Expression(yul::Expression::FunctionCall(yul::FunctionCall {
+                    identifier: base::untyped_identifier("return"),
+                    arguments: vec![
+                        base::untyped_literal_expr("0"),
+                        base::untyped_identifier_expr("size"),
+                    ],
+                })),
+            ],
+        },
+    }
+}
+
+#[test]
+fn test_constructor() {
+    assert_eq!(
+        code().to_string(),
+        r#"code { let size := datasize("runtime") datacopy(0, dataoffset("runtime"), size) return(0, size) }"#,
+        "incorrect constructor"
+    )
+}

--- a/compiler/src/yul/constructor.rs
+++ b/compiler/src/yul/constructor.rs
@@ -1,7 +1,9 @@
 use crate::yul::base;
 use yultsur::yul;
 
-/// Builds the code block that returns the runtime object.
+/// Builds a code block that returns the runtime object.
+///
+/// TODO: Add real constructor code here.
 pub fn code() -> yul::Code {
     yul::Code {
         block: yul::Block {

--- a/compiler/src/yul/mod.rs
+++ b/compiler/src/yul/mod.rs
@@ -1,0 +1,17 @@
+use crate::errors::CompileError;
+use vyper_parser as parser;
+
+mod base;
+mod constructor;
+mod ast_builder;
+mod selectors;
+
+pub fn compile(src: &str) -> Result<String, CompileError> {
+    let tokens = parser::get_parse_tokens(src)?;
+    let vyp_module = parser::parsers::file_input(&tokens[..])?.1.node;
+    if let Ok(yul_ast) = ast_builder::module(&vyp_module) {
+        return Ok(yul_ast.to_string());
+    }
+
+    Err(CompileError::static_str("Unable to parse tokens."))
+}

--- a/compiler/src/yul/mod.rs
+++ b/compiler/src/yul/mod.rs
@@ -1,16 +1,19 @@
 use crate::errors::CompileError;
 use vyper_parser as parser;
 
+mod ast_builder;
 mod base;
 mod constructor;
-mod ast_builder;
 mod selectors;
 
+/// Builds Yul code from Vyper source.
 pub fn compile(src: &str) -> Result<String, CompileError> {
     let tokens = parser::get_parse_tokens(src)?;
     let vyp_module = parser::parsers::file_input(&tokens[..])?.1.node;
-    if let Ok(yul_ast) = ast_builder::module(&vyp_module) {
-        return Ok(yul_ast.to_string());
+
+    // TODO: Handle multiple contracts in one Vyper module cleanly.
+    if let Some(first_contract) = ast_builder::module(&vyp_module)?.get(0) {
+        return Ok(first_contract.to_string());
     }
 
     Err(CompileError::static_str("Unable to parse tokens."))

--- a/compiler/src/yul/selectors.rs
+++ b/compiler/src/yul/selectors.rs
@@ -1,13 +1,14 @@
 use crate::errors::CompileError;
 use crate::yul::base;
 use yultsur::yul;
+use tiny_keccak::{Hasher, Keccak};
 
 /// Builds a switch statement from the contract ABI.
 /// The switch's expression is the 4 left-most bytes in the calldata and each case is
 /// defined as the keccak value of each function's signature (without return data).
-pub fn switch(functions: &Vec<ethabi::Function>) -> Result<yul::Switch, CompileError> {
+pub fn switch(functions: Vec<&ethabi::Function>) -> Result<yul::Switch, CompileError> {
     let cases = functions
-        .iter()
+        .into_iter()
         .map(|function| case(function))
         .collect::<Result<Vec<yul::Case>, CompileError>>()?;
 
@@ -18,7 +19,7 @@ pub fn switch(functions: &Vec<ethabi::Function>) -> Result<yul::Switch, CompileE
 }
 
 /// Builds an expression that loads the first 4 bytes of the calldata.
-fn expression() -> yul::Expression {
+pub fn expression() -> yul::Expression {
     yul::Expression::FunctionCall(yul::FunctionCall {
         identifier: base::untyped_identifier("shr"),
         arguments: vec![
@@ -37,11 +38,9 @@ fn expression() -> yul::Expression {
 ///
 /// Currently, this assumes each input and the single output is 256 bits.
 /// TODO: Handle types of different sizes: https://solidity.readthedocs.io/en/v0.6.2/abi-spec.html#types
-fn case(function: &ethabi::Function) -> Result<yul::Case, CompileError> {
-    let selector = vec![0]; // TODO: Load actual selector with ABI module.
-
+pub fn case(function: &ethabi::Function) -> Result<yul::Case, CompileError> {
     Ok(yul::Case {
-        literal: Some(base::untyped_literal(&format!("0x{}", hex::encode(selector)))),
+        literal: Some(selector_literal(function.signature())),
         block: yul::Block {
             statements: vec![
                 yul::Statement::Expression(yul::Expression::FunctionCall(yul::FunctionCall {
@@ -72,11 +71,87 @@ fn case(function: &ethabi::Function) -> Result<yul::Case, CompileError> {
     })
 }
 
-#[test]
-fn test_expression() {
-    assert_eq!(
-        expression().to_string(),
-        "shr(224, calldataload(0))",
-        "Switch expression not correct."
-    )
+/// Computes the keccak-256 value of the input portion of the function signature and returns the
+/// first 4 bytes.
+///
+/// Example: "foo(uint256):(uint256)" => keccak256("foo(uint256)")
+pub fn selector_literal(sig: String) -> yul::Literal {
+    let mut sig_halves = sig.split(":");
+
+    let mut keccak = Keccak::v256();
+    let mut selector = [0u8; 4];
+
+    if let Some(first_half) = sig_halves.next() {
+        keccak.update(first_half.as_bytes());
+        keccak.finalize(&mut selector);
+    }
+
+    base::untyped_literal(&format!("0x{}", hex::encode(selector)))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::yul::selectors::{expression, selector_literal, case, switch};
+    use stringreader::StringReader;
+
+    #[test]
+    fn test_expression() {
+        assert_eq!(
+            expression().to_string(),
+            "shr(224, calldataload(0))",
+            "Switch expression not correct."
+        )
+    }
+
+    #[test]
+    fn test_selector_literal_basic() {
+        let json_abi = r#"[{"name": "foo", "type": "function", "inputs": [], "outputs": []}]"#;
+        let abi = ethabi::Contract::load(StringReader::new(json_abi)).expect("Unable to load abi.");
+        let ref foo = abi.functions["foo"][0];
+
+        assert_eq!(
+            selector_literal(foo.signature()).to_string(),
+            String::from("0xc2985578"),
+            "Incorrect selector"
+        )
+    }
+
+    #[test]
+    fn test_selector_literal() {
+        let json_abi = r#"[{"name": "foo", "type": "function", "inputs": [{ "name": "bar", "type": "uint256" }], "outputs": []}]"#;
+        let abi = ethabi::Contract::load(StringReader::new(json_abi)).expect("Unable to load abi.");
+        let ref foo = abi.functions["foo"][0];
+
+        assert_eq!(
+            selector_literal(foo.signature()).to_string(),
+            String::from("0x2fbebd38"),
+            "Incorrect selector"
+        )
+    }
+
+    #[test]
+    fn test_case() {
+        let json_abi = r#"[{"name": "foo", "type": "function", "inputs": [{ "name": "bar", "type": "uint256" }], "outputs": []}]"#;
+        let abi = ethabi::Contract::load(StringReader::new(json_abi)).expect("Unable to load abi.");
+        let ref foo = abi.functions["foo"][0];
+
+        assert_eq!(
+            case(foo).expect("Unable to build case.").to_string(),
+            String::from("case 0x2fbebd38 { mstore(0, foo(calldataload(4))) return(0, 32) }"),
+            "Incorrect case"
+        );
+    }
+
+    #[test]
+    fn test_switch_basic() {
+        let json_abi = r#"[{"name": "foo", "type": "function", "inputs": [], "outputs": []}]"#;
+        let abi = ethabi::Contract::load(StringReader::new(json_abi)).expect("Unable to load abi.");
+        let functions = abi.functions().collect();
+
+        assert_eq!(
+            switch(functions).expect("Unable to build selector").to_string(),
+            String::from("switch shr(224, calldataload(0)) case 0xc2985578 { mstore(0, foo()) return(0, 32) } "),
+            "Incorrect selector"
+        )
+    }
 }

--- a/compiler/src/yul/selectors.rs
+++ b/compiler/src/yul/selectors.rs
@@ -1,0 +1,82 @@
+use crate::errors::CompileError;
+use crate::yul::base;
+use yultsur::yul;
+
+/// Builds a switch statement from the contract ABI.
+/// The switch's expression is the 4 left-most bytes in the calldata and each case is
+/// defined as the keccak value of each function's signature (without return data).
+pub fn switch(functions: &Vec<ethabi::Function>) -> Result<yul::Switch, CompileError> {
+    let cases = functions
+        .iter()
+        .map(|function| case(function))
+        .collect::<Result<Vec<yul::Case>, CompileError>>()?;
+
+    Ok(yul::Switch {
+        expression: expression(),
+        cases,
+    })
+}
+
+/// Builds an expression that loads the first 4 bytes of the calldata.
+fn expression() -> yul::Expression {
+    yul::Expression::FunctionCall(yul::FunctionCall {
+        identifier: base::untyped_identifier("shr"),
+        arguments: vec![
+            base::untyped_literal_expr("224"),
+            yul::Expression::FunctionCall(yul::FunctionCall {
+                identifier: base::untyped_identifier("calldataload"),
+                arguments: vec![base::untyped_literal_expr("0")],
+            }),
+        ],
+    })
+}
+
+/// Builds a switch case from the function. It matches the selector and calls
+/// the function as described in the ABI. The value (if any) returned by the
+/// function is stored in memory and returned by the contract.
+///
+/// Currently, this assumes each input and the single output is 256 bits.
+/// TODO: Handle types of different sizes: https://solidity.readthedocs.io/en/v0.6.2/abi-spec.html#types
+fn case(function: &ethabi::Function) -> Result<yul::Case, CompileError> {
+    let selector = vec![0]; // TODO: Load actual selector with ABI module.
+
+    Ok(yul::Case {
+        literal: Some(base::untyped_literal(&format!("0x{}", hex::encode(selector)))),
+        block: yul::Block {
+            statements: vec![
+                yul::Statement::Expression(yul::Expression::FunctionCall(yul::FunctionCall {
+                    identifier: base::untyped_identifier("mstore"),
+                    arguments: vec![
+                        base::untyped_literal_expr("0"),
+                        yul::Expression::FunctionCall(yul::FunctionCall {
+                            identifier: base::untyped_identifier(&function.name),
+                            arguments: (0..function.inputs.len())
+                                .map(|n| {
+                                    base::untyped_literal_expr(
+                                        format!("calldataload({})", n * 32 + 4).as_ref(),
+                                    )
+                                })
+                                .collect(),
+                        }),
+                    ],
+                })),
+                yul::Statement::Expression(yul::Expression::FunctionCall(yul::FunctionCall {
+                    identifier: base::untyped_identifier("return"),
+                    arguments: vec![
+                        base::untyped_literal_expr("0"),
+                        base::untyped_literal_expr("32"),
+                    ],
+                })),
+            ],
+        },
+    })
+}
+
+#[test]
+fn test_expression() {
+    assert_eq!(
+        expression().to_string(),
+        "shr(224, calldataload(0))",
+        "Switch expression not correct."
+    )
+}

--- a/compiler/src/yul/selectors.rs
+++ b/compiler/src/yul/selectors.rs
@@ -1,7 +1,7 @@
 use crate::errors::CompileError;
 use crate::yul::base;
-use yultsur::yul;
 use tiny_keccak::{Hasher, Keccak};
+use yultsur::yul;
 
 /// Builds a switch statement from the contract ABI.
 /// The switch's expression is the 4 left-most bytes in the calldata and each case is
@@ -42,19 +42,17 @@ pub fn case(function: &ethabi::Function) -> Result<yul::Case, CompileError> {
     let selector = Some(selector_literal(function.signature()));
 
     if function.outputs.is_empty() {
-        return Ok(
-            yul::Case {
-                literal: selector,
-                block: yul::Block {
-                    statements: vec![
-                        yul::Statement::Expression(yul::Expression::FunctionCall(yul::FunctionCall {
-                            identifier: base::untyped_identifier("foo"),
-                            arguments: vec![]
-                        }))
-                    ]
-                }
-            }
-        )
+        return Ok(yul::Case {
+            literal: selector,
+            block: yul::Block {
+                statements: vec![yul::Statement::Expression(yul::Expression::FunctionCall(
+                    yul::FunctionCall {
+                        identifier: base::untyped_identifier("foo"),
+                        arguments: vec![],
+                    },
+                ))],
+            },
+        });
     }
 
     Ok(yul::Case {
@@ -109,7 +107,7 @@ pub fn selector_literal(sig: String) -> yul::Literal {
 
 #[cfg(test)]
 mod tests {
-    use crate::yul::selectors::{expression, selector_literal, case, switch};
+    use crate::yul::selectors::{case, expression, selector_literal, switch};
     use stringreader::StringReader;
 
     #[test]
@@ -167,7 +165,9 @@ mod tests {
         let functions = abi.functions().collect();
 
         assert_eq!(
-            switch(functions).expect("Unable to build selector").to_string(),
+            switch(functions)
+                .expect("Unable to build selector")
+                .to_string(),
             String::from("switch shr(224, calldataload(0)) case 0xc2985578 { foo() } "),
             "Incorrect selector"
         )


### PR DESCRIPTION
Part of #10.

This includes just enough functionality to compile a contract like this:

```
contract Foo:
    pub def bar(x: u256) -> u256:
        return x
```

To keep it simple, types are basically ignored (everyting is `u256`) and all variables are stored on the stack. There are some `Scope` data structures in here as well, which aren't necessary for it to work, but would be worth reviewing as I intend to build more complexity on top of them.

The Yul code generated by the compiler would not actually be runnable, since it doesn't have the ABI builder from #15 to generate the selector switch from. In #17, I add that to this module and demonstrate that the contract can be deployed and ran in a test.