### PR TITLE
Bytecode compiler and EVM tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,10 +2,18 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aho-corasick"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -19,11 +27,44 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hermit-abi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "base64"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cexpr 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "which 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -38,7 +79,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bumpalo"
-version = "2.6.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -48,7 +89,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
-version = "1.3.2"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -60,9 +101,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cexpr"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clang-sys"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clap"
+version = "2.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "console_error_panic_hook"
@@ -70,7 +156,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -84,6 +170,18 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ethabi"
 version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,7 +189,7 @@ dependencies = [
  "ethereum-types 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uint 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -126,7 +224,7 @@ name = "fixed-hash"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -148,6 +246,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,9 +259,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "impl-codec"
@@ -194,15 +313,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "js-sys"
-version = "0.3.33"
+version = "0.3.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "wasm-bindgen 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -211,9 +330,23 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "lazycell"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libc"
 version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libloading"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "log"
@@ -225,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.2.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -233,7 +366,7 @@ name = "nom"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -247,6 +380,11 @@ dependencies = [
  "byte-slice-cast 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ppv-lite86"
@@ -275,11 +413,16 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
@@ -294,7 +437,7 @@ name = "quote"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -336,18 +479,18 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.3.1"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.12"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -367,6 +510,11 @@ dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-hex"
@@ -396,19 +544,33 @@ name = "serde_derive"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.44"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "shlex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "solc"
+version = "0.1.0"
+source = "git+https://github.com/g-r-a-n-t/solc-rust#6694346d0fb038ce37e8bee6d4d8d4ad38a9d884"
+dependencies = [
+ "bindgen 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -427,18 +589,39 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "syn"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread_local"
-version = "0.3.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -465,7 +648,7 @@ name = "uint"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -477,6 +660,11 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +672,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-xid"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -503,18 +696,11 @@ dependencies = [
 name = "vyper-compiler"
 version = "0.1.0"
 dependencies = [
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "vyper-compiler 0.1.0",
- "vyper-parser 0.1.0",
-]
-
-[[package]]
-name = "vyper-compiler"
-version = "0.1.0"
-dependencies = [
  "ethabi 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solc 0.1.0 (git+https://github.com/g-r-a-n-t/solc-rust)",
  "stringreader 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vyper-parser 0.1.0",
@@ -526,11 +712,11 @@ name = "vyper-parser"
 version = "0.1.0"
 dependencies = [
  "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-test 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -541,25 +727,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.56"
+version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.56"
+version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bumpalo 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -569,35 +755,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.56"
+version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro-support 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro-support 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.56"
+version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-backend 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.56"
+version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -607,9 +793,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-futures 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-test-macro 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -625,29 +811,29 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-webidl"
-version = "0.2.56"
+version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-backend 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.33"
+version = "0.3.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-webidl 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-webidl 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -659,87 +845,151 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "yultsur"
 version = "0.1.0"
 source = "git+https://github.com/g-r-a-n-t/yultsur#db1336ac92b85ae6d07af63918e0bfb1afb71f4a"
 
 [metadata]
-"checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
+"checksum aho-corasick 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "743ad5a418686aad3b87fd14c43badd828cf26e214a00f92a384291cf22e1811"
+"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+"checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+"checksum bindgen 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f1c85344eb535a31b62f0af37be84441ba9e7f0f4111eb0530f43d15e513fe57"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a993f74b4c99c1908d156b8d2e0fb6277736b0ecbd833982fd1241d39b2766a6"
-"checksum bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad807f2fc2bf185eeb98ff3a901bd46dc5ad58163d0fa4577ba0d25674d71708"
+"checksum bumpalo 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742"
 "checksum byte-slice-cast 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
-"checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
+"checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
+"checksum cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
+"checksum cexpr 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+"checksum clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
+"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+"checksum cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
 "checksum console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
 "checksum crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+"checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 "checksum ethabi 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97652a7d1f2504d6c885c87e242a06ccef5bd3054093d3fb742d8fb64806231a"
 "checksum ethbloom 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "32cfe1c169414b709cf28aa30c74060bdb830a03a8ba473314d079ac79d80a5f"
 "checksum ethereum-types 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba744248e3553a393143d5ebb68939fc3a4ec0c22a269682535f5ffe7fed728c"
 "checksum fixed-hash 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3367952ceb191f4ab95dd5685dc163ac539e36202f9fcfd0cb22f9f9c542fefc"
 "checksum futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+"checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+"checksum hermit-abi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "e2c55f143919fbc0bc77e427fe2d74cf23786d7c1875666f2fde3ac3c659bb67"
 "checksum hex 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "76cdda6bf525062a0c9e8f14ee2b37935c86b8efb6c8b69b3c83dfb518a914af"
+"checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum impl-codec 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1be51a921b067b0eaca2fad532d9400041561aa922221cc65f95a85641c6bf53"
 "checksum impl-rlp 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8f7a72f11830b52333f36e3b09a288333888bf54380fd0ac0790a3c31ab0f3c5"
 "checksum impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "58e3cae7e99c7ff5a995da2cf78dd0a5383740eda71d98cf7b1910c301ac69b8"
 "checksum impl-serde 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5bbe9ea9b182f0fb1cabbd61f4ff9b7b7b9197955e95a7e4c27de5055eb29ff8"
-"checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
-"checksum js-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)" = "367647c532db6f1555d7151e619540ec5f713328235b8c062c6b4f63e84adfe3"
+"checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+"checksum js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "7889c7c36282151f6bf465be4700359318aef36baa951462382eae49e9577cf9"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+"checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
+"checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
-"checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
+"checksum memchr 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53445de381a1f436797497c61d851644d0e8e88e6140f22872ad33a704933978"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f747c06d9f3b2ad387ac881b9667298c81b1243aa9833f086e05996937c35507"
+"checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e4336f4f5d5524fa60bcbd6fe626f9223d8142a50e7053e979acdf0da41ab975"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-"checksum proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0319972dcae462681daf4da1adeeaa066e3ebd29c69be96c6abb1259d2ee2bcc"
+"checksum proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
+"checksum quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 "checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
 "checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 "checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-"checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
-"checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
+"checksum regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8"
+"checksum regex-syntax 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "b28dfe3fe9badec5dbf0a79a9cccad2cfc2ab5484bdb3e44cbd1ae8b3ba2be06"
 "checksum rlp 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3a44d5ae8afcb238af8b75640907edc6c931efcfab2c854e81ed35fa080f84cd"
 "checksum ron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2ece421e0c4129b90e4a35b6f625e472e96c552136f5093a2f4fa2bbb75a62d5"
+"checksum rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 "checksum rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 "checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
 "checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
-"checksum serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)" = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
+"checksum serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
+"checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+"checksum solc 0.1.0 (git+https://github.com/g-r-a-n-t/solc-rust)" = "<none>"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 "checksum stringreader 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "913e7b03d63752f6cdd2df77da36749d82669904798fe8944b9ec3d23f159905"
-"checksum syn 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ddc157159e2a7df58cd67b1cace10b8ed256a404fb0070593f137d8ba6bef4de"
-"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+"checksum syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
+"checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
 "checksum tiny-keccak 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2953ca5148619bc99695c1274cb54c5275bbb913c6adad87e72eaf8db9787f69"
 "checksum uint 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e75a4cdd7b87b28840dba13c483b9a88ee6bbf16ba5c951ee1ecfcf723078e0d"
 "checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+"checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-"checksum wasm-bindgen 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)" = "99de4b68939a880d530aed51289a7c7baee154e3ea8ac234b542c49da7134aaf"
-"checksum wasm-bindgen-backend 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)" = "b58e66a093a7b7571cb76409763c495b8741ac4319ac20acc2b798f6766d92ee"
+"checksum wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "5205e9afdf42282b192e2310a5b463a6d1c1d774e30dc3c791ac37ab42d2616c"
+"checksum wasm-bindgen-backend 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "11cdb95816290b525b32587d76419facd99662a07e59d3cdb560488a819d9a45"
 "checksum wasm-bindgen-futures 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)" = "83420b37346c311b9ed822af41ec2e82839bfe99867ec6c54e2da43b7538771c"
-"checksum wasm-bindgen-macro 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)" = "a80f89daea7b0a67b11f6e9f911422ed039de9963dce00048a653b63d51194bf"
-"checksum wasm-bindgen-macro-support 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)" = "4f9dbc3734ad6cff6b76b75b7df98c06982becd0055f651465a08f769bca5c61"
-"checksum wasm-bindgen-shared 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)" = "d907984f8506b3554eab48b8efff723e764ddbf76d4cd4a3fe4196bc00c49a70"
+"checksum wasm-bindgen-macro 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "574094772ce6921576fb6f2e3f7497b8a76273b6db092be18fc48a082de09dc3"
+"checksum wasm-bindgen-macro-support 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "e85031354f25eaebe78bb7db1c3d86140312a911a106b2e29f9cc440ce3e7668"
+"checksum wasm-bindgen-shared 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "f5e7e61fc929f4c0dddb748b102ebf9f632e2b8d739f2016542b4de2965a9601"
 "checksum wasm-bindgen-test 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)" = "a2d9693b63a742d481c7f80587e057920e568317b2806988c59cd71618bc26c1"
 "checksum wasm-bindgen-test-macro 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)" = "0789dac148a8840bbcf9efe13905463b733fa96543bfbf263790535c11af7ba5"
-"checksum wasm-bindgen-webidl 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)" = "f85a3825a459cf6a929d03bacb54dca37a614d43032ad1343ef2d4822972947d"
-"checksum web-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)" = "2fb60433d0dc12c803b9b017b3902d80c9451bab78d27bc3210bf2a7b96593f1"
+"checksum wasm-bindgen-webidl 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "ef012a0d93fc0432df126a8eaf547b2dce25a8ce9212e1d3cbeef5c11157975d"
+"checksum web-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "aaf97caf6aa8c2b1dac90faf0db529d9d63c93846cca4911856f78a83cebf53b"
 "checksum weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164"
+"checksum which 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5475d47078209a02e60614f7ba5e645ef3ed60f771920ac1906d7c1cc65024c8"
+"checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum yultsur 0.1.0 (git+https://github.com/g-r-a-n-t/yultsur)" = "<none>"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,25 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +104,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "byte-slice-cast"
 version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -170,6 +194,14 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +252,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "evm"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "evm-core 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "evm-gasometer 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "evm-runtime 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rlp 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "evm-core"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "evm-gasometer"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "evm-core 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "evm-runtime 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "evm-runtime"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "evm-core 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +308,14 @@ dependencies = [
 name = "futures"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "generic-array"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "getrandom"
@@ -325,6 +407,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,6 +456,11 @@ dependencies = [
  "memchr 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "parity-scale-codec"
@@ -560,6 +652,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,6 +748,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "uint"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,7 +806,10 @@ name = "vyper-compiler"
 version = "0.1.0"
 dependencies = [
  "ethabi 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "evm 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "evm-runtime 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "solc 0.1.0 (git+https://github.com/g-r-a-n-t/solc-rust)",
@@ -894,8 +1006,11 @@ source = "git+https://github.com/g-r-a-n-t/yultsur#db1336ac92b85ae6d07af63918e0b
 "checksum bindgen 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f1c85344eb535a31b62f0af37be84441ba9e7f0f4111eb0530f43d15e513fe57"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a993f74b4c99c1908d156b8d2e0fb6277736b0ecbd833982fd1241d39b2766a6"
+"checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+"checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 "checksum bumpalo 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742"
 "checksum byte-slice-cast 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
+"checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
@@ -907,12 +1022,18 @@ source = "git+https://github.com/g-r-a-n-t/yultsur#db1336ac92b85ae6d07af63918e0b
 "checksum console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
 "checksum crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+"checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 "checksum ethabi 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97652a7d1f2504d6c885c87e242a06ccef5bd3054093d3fb742d8fb64806231a"
 "checksum ethbloom 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "32cfe1c169414b709cf28aa30c74060bdb830a03a8ba473314d079ac79d80a5f"
 "checksum ethereum-types 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba744248e3553a393143d5ebb68939fc3a4ec0c22a269682535f5ffe7fed728c"
+"checksum evm 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73f887b371f9999682ccc5b1cb771e7d4408ae61e93fc0343ceaeb761fca42d1"
+"checksum evm-core 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3bcde5af3d542874ddeb53de0919302d57586ea04b3f76f54d865f8a6cdc70ae"
+"checksum evm-gasometer 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b82bc9f275cb59d2bcc05d85c98736ddfaba003a7ef7b73893fa7c1c1fab29dc"
+"checksum evm-runtime 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0dbbc89d29618c3722c17ba78ddf432d40ace8ee27e3f8b28b52a85921112e4b"
 "checksum fixed-hash 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3367952ceb191f4ab95dd5685dc163ac539e36202f9fcfd0cb22f9f9c542fefc"
 "checksum futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
+"checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
@@ -925,6 +1046,7 @@ source = "git+https://github.com/g-r-a-n-t/yultsur#db1336ac92b85ae6d07af63918e0b
 "checksum impl-serde 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5bbe9ea9b182f0fb1cabbd61f4ff9b7b7b9197955e95a7e4c27de5055eb29ff8"
 "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 "checksum js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "7889c7c36282151f6bf465be4700359318aef36baa951462382eae49e9577cf9"
+"checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
@@ -932,6 +1054,7 @@ source = "git+https://github.com/g-r-a-n-t/yultsur#db1336ac92b85ae6d07af63918e0b
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum memchr 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53445de381a1f436797497c61d851644d0e8e88e6140f22872ad33a704933978"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+"checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f747c06d9f3b2ad387ac881b9667298c81b1243aa9833f086e05996937c35507"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
@@ -956,6 +1079,7 @@ source = "git+https://github.com/g-r-a-n-t/yultsur#db1336ac92b85ae6d07af63918e0b
 "checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
 "checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 "checksum serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
+"checksum sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd26bc0e7a2e3a7c959bc494caf58b72ee0c71d67704e9520f736ca7e4853ecf"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum solc 0.1.0 (git+https://github.com/g-r-a-n-t/solc-rust)" = "<none>"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
@@ -968,6 +1092,7 @@ source = "git+https://github.com/g-r-a-n-t/yultsur#db1336ac92b85ae6d07af63918e0b
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
 "checksum tiny-keccak 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2953ca5148619bc99695c1274cb54c5275bbb913c6adad87e72eaf8db9787f69"
+"checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 "checksum uint 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e75a4cdd7b87b28840dba13c483b9a88ee6bbf16ba5c951ee1ecfcf723078e0d"
 "checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "vyper"
 version = "0.1.0"
 dependencies = [
+ "vyper-compiler 0.1.0",
+ "vyper-parser 0.1.0",
+]
+
+[[package]]
+name = "vyper-compiler"
+version = "0.1.0"
+dependencies = [
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "vyper-parser 0.1.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,11 @@ version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "base64"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,14 +32,32 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bitvec"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bumpalo"
 version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byte-slice-cast"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "c2-chacha"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cfg-if"
@@ -51,9 +74,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ethabi"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ethereum-types 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uint 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixed-hash 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-rlp 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ethbloom 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixed-hash 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-rlp 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uint 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "futures"
@@ -61,11 +138,58 @@ version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "getrandom"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hex"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "impl-codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rlp 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -84,6 +208,11 @@ dependencies = [
 [[package]]
 name = "lazy_static"
 version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -106,6 +235,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-slice-cast 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "primitive-types"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fixed-hash 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-codec 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-rlp 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-serde 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uint 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -141,6 +298,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +351,14 @@ version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rlp"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ron"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,6 +367,11 @@ dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ryu"
@@ -210,6 +417,16 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "stringreader"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "syn"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +442,33 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "uint"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -261,7 +505,20 @@ version = "0.1.0"
 dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vyper-compiler 0.1.0",
  "vyper-parser 0.1.0",
+]
+
+[[package]]
+name = "vyper-compiler"
+version = "0.1.0"
+dependencies = [
+ "ethabi 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stringreader 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vyper-parser 0.1.0",
+ "yultsur 0.1.0 (git+https://github.com/g-r-a-n-t/yultsur)",
 ]
 
 [[package]]
@@ -276,6 +533,11 @@ dependencies = [
  "wasm-bindgen 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-test 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wasm-bindgen"
@@ -396,43 +658,79 @@ dependencies = [
  "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "yultsur"
+version = "0.1.0"
+source = "git+https://github.com/g-r-a-n-t/yultsur#db1336ac92b85ae6d07af63918e0bfb1afb71f4a"
+
 [metadata]
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
+"checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+"checksum bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a993f74b4c99c1908d156b8d2e0fb6277736b0ecbd833982fd1241d39b2766a6"
 "checksum bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad807f2fc2bf185eeb98ff3a901bd46dc5ad58163d0fa4577ba0d25674d71708"
+"checksum byte-slice-cast 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
+"checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
+"checksum crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+"checksum ethabi 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97652a7d1f2504d6c885c87e242a06ccef5bd3054093d3fb742d8fb64806231a"
+"checksum ethbloom 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "32cfe1c169414b709cf28aa30c74060bdb830a03a8ba473314d079ac79d80a5f"
+"checksum ethereum-types 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba744248e3553a393143d5ebb68939fc3a4ec0c22a269682535f5ffe7fed728c"
+"checksum fixed-hash 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3367952ceb191f4ab95dd5685dc163ac539e36202f9fcfd0cb22f9f9c542fefc"
 "checksum futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
+"checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+"checksum hex 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "76cdda6bf525062a0c9e8f14ee2b37935c86b8efb6c8b69b3c83dfb518a914af"
+"checksum impl-codec 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1be51a921b067b0eaca2fad532d9400041561aa922221cc65f95a85641c6bf53"
+"checksum impl-rlp 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8f7a72f11830b52333f36e3b09a288333888bf54380fd0ac0790a3c31ab0f3c5"
+"checksum impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "58e3cae7e99c7ff5a995da2cf78dd0a5383740eda71d98cf7b1910c301ac69b8"
+"checksum impl-serde 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5bbe9ea9b182f0fb1cabbd61f4ff9b7b7b9197955e95a7e4c27de5055eb29ff8"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum js-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)" = "367647c532db6f1555d7151e619540ec5f713328235b8c062c6b4f63e84adfe3"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+"checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+"checksum parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f747c06d9f3b2ad387ac881b9667298c81b1243aa9833f086e05996937c35507"
+"checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+"checksum primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e4336f4f5d5524fa60bcbd6fe626f9223d8142a50e7053e979acdf0da41ab975"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0319972dcae462681daf4da1adeeaa066e3ebd29c69be96c6abb1259d2ee2bcc"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+"checksum rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+"checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
+"checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+"checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
+"checksum rlp 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3a44d5ae8afcb238af8b75640907edc6c931efcfab2c854e81ed35fa080f84cd"
 "checksum ron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2ece421e0c4129b90e4a35b6f625e472e96c552136f5093a2f4fa2bbb75a62d5"
+"checksum rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 "checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
 "checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 "checksum serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)" = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
+"checksum static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+"checksum stringreader 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "913e7b03d63752f6cdd2df77da36749d82669904798fe8944b9ec3d23f159905"
 "checksum syn 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ddc157159e2a7df58cd67b1cace10b8ed256a404fb0070593f137d8ba6bef4de"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
+"checksum tiny-keccak 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2953ca5148619bc99695c1274cb54c5275bbb913c6adad87e72eaf8db9787f69"
+"checksum uint 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e75a4cdd7b87b28840dba13c483b9a88ee6bbf16ba5c951ee1ecfcf723078e0d"
 "checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 "checksum wasm-bindgen 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)" = "99de4b68939a880d530aed51289a7c7baee154e3ea8ac234b542c49da7134aaf"
 "checksum wasm-bindgen-backend 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)" = "b58e66a093a7b7571cb76409763c495b8741ac4319ac20acc2b798f6766d92ee"
 "checksum wasm-bindgen-futures 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)" = "83420b37346c311b9ed822af41ec2e82839bfe99867ec6c54e2da43b7538771c"
@@ -444,3 +742,4 @@ dependencies = [
 "checksum wasm-bindgen-webidl 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)" = "f85a3825a459cf6a929d03bacb54dca37a614d43032ad1343ef2d4822972947d"
 "checksum web-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)" = "2fb60433d0dc12c803b9b017b3902d80c9451bab78d27bc3210bf2a7b96593f1"
 "checksum weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164"
+"checksum yultsur 0.1.0 (git+https://github.com/g-r-a-n-t/yultsur)" = "<none>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ categories = ["cryptography::cryptocurrencies", "command-line-utilities", "devel
 readme = "README.md"
 
 [workspace]
-members = [".", "parser"]
+members = [".", "parser", "compiler"]
 
 [dependencies]
 vyper-parser = {path = "parser", version = "0.1.0"}
+vyper-compiler = {path = "compiler", version = "0.1.0"}

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -16,3 +16,8 @@ solc = { git = "https://github.com/g-r-a-n-t/solc-rust" }
 ethabi = "11.0"
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 stringreader = "0.1"
+
+[dev-dependencies]
+evm = "0.14"
+primitive-types = "0.6"
+evm-runtime = "0.14"

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -10,3 +10,8 @@ edition = "2018"
 vyper-parser = {path = "../parser", version = "0.1.0"}
 serde_json = "1.0"
 serde = "1.0"
+hex = "0.4"
+yultsur = { git = "https://github.com/g-r-a-n-t/yultsur" }
+ethabi = "11.0"
+tiny-keccak = { version = "2.0", features = ["keccak"] }
+stringreader = "0.1"

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -12,6 +12,7 @@ serde_json = "1.0"
 serde = "1.0"
 hex = "0.4"
 yultsur = { git = "https://github.com/g-r-a-n-t/yultsur" }
+solc = { git = "https://github.com/g-r-a-n-t/solc-rust" }
 ethabi = "11.0"
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 stringreader = "0.1"

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "vyper-compiler"
+version = "0.1.0"
+authors = ["Grant Wuerker <gwuerker@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+vyper-parser = {path = "../parser", version = "0.1.0"}
+serde_json = "1.0"
+serde = "1.0"

--- a/compiler/src/abi/json.rs
+++ b/compiler/src/abi/json.rs
@@ -1,0 +1,216 @@
+use crate::errors::CompileError;
+use serde::Serialize;
+use std::collections::HashMap;
+use vyper_parser as parser;
+use vyper_parser::ast as vyp;
+
+type TypeDefs<'a> = HashMap<&'a str, &'a vyp::TypeDesc<'a>>;
+
+#[derive(Serialize)]
+pub struct Contract {
+    functions: Vec<Function>,
+}
+
+#[derive(Serialize)]
+struct Function {
+    name: String,
+    #[serde(rename = "type")]
+    typ: FunctionType,
+    inputs: Vec<Input>,
+    outputs: Vec<Output>,
+}
+
+#[derive(Serialize)]
+struct Input {
+    name: String,
+    #[serde(rename = "type")]
+    typ: VariableType,
+}
+
+#[derive(Serialize)]
+struct Output {
+    name: String,
+    #[serde(rename = "type")]
+    typ: VariableType,
+}
+
+#[allow(dead_code)]
+#[serde(rename_all = "lowercase")]
+#[derive(Serialize)]
+enum FunctionType {
+    Function,
+    Constructor,
+    Receive,
+    Fallback,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "lowercase")]
+enum VariableType {
+    Uint256,
+}
+
+impl ToString for VariableType {
+    fn to_string(&self) -> String {
+        match self {
+            VariableType::Uint256 => String::from("uint256"),
+        }
+    }
+}
+
+#[allow(dead_code)]
+#[serde(rename_all = "lowercase")]
+#[derive(Serialize)]
+enum StateMutability {
+    Pure,
+    View,
+    Nonpayable,
+    Payable,
+}
+
+pub fn compile(src: &str) -> Result<String, CompileError> {
+    let tokens = parser::get_parse_tokens(src).unwrap();
+    let vyp_module = parser::parsers::file_input(&tokens[..]).unwrap().1.node;
+    let contracts = module(&vyp_module)?;
+
+    // TODO: Handle multiple contracts in one source file.
+    if let Some(contract) = contracts.get(0) {
+        return Ok(serde_json::to_string(&contract.functions)?);
+    }
+
+    Err(CompileError::static_str(
+        "No contract statements in source.",
+    ))
+}
+
+fn module<'a>(module: &'a vyp::Module) -> Result<Vec<Contract>, CompileError> {
+    let type_defs: TypeDefs<'a> = module
+        .body
+        .iter()
+        .filter_map(|stmt| match stmt.node {
+            vyp::ModuleStmt::TypeDef { ref name, ref typ } => Some((name.node, &typ.node)),
+            _ => None,
+        })
+        .collect();
+
+    module
+        .body
+        .iter()
+        .filter_map(|stmt| match stmt.node {
+            vyp::ModuleStmt::ContractDef { .. } => Some(contract_def(&type_defs, &stmt.node)),
+            _ => None,
+        })
+        .collect::<Result<Vec<Contract>, CompileError>>()
+}
+
+fn contract_def<'a>(
+    type_defs: &'a TypeDefs<'a>,
+    stmt: &'a vyp::ModuleStmt<'a>,
+) -> Result<Contract, CompileError> {
+    if let vyp::ModuleStmt::ContractDef { name: _, body } = stmt {
+        return Ok(Contract {
+            functions: body
+                .iter()
+                .map(|stmt| func_def(type_defs, &stmt.node))
+                .collect::<Result<Vec<Option<Function>>, CompileError>>()?
+                .into_iter()
+                .filter_map(|function| function)
+                .collect(),
+        });
+    }
+
+    Err(CompileError::static_str(
+        "Contract definition translation requires ContractDef parameter.",
+    ))
+}
+
+fn func_def<'a>(
+    type_defs: &'a TypeDefs<'a>,
+    stmt: &'a vyp::ContractStmt<'a>,
+) -> Result<Option<Function>, CompileError> {
+    if let vyp::ContractStmt::FuncDef {
+        qual,
+        name,
+        args,
+        return_type,
+        body: _,
+    } = stmt
+    {
+        if qual.is_none() {
+            return Ok(None); // Private method.
+        }
+
+        let outputs = if let Some(return_type) = return_type {
+            vec![Output {
+                name: String::from("return_value"),
+                typ: type_desc(type_defs, &return_type.node)?,
+            }]
+        } else {
+            Vec::new()
+        };
+
+        return Ok(Some(Function {
+            name: String::from(name.node),
+            typ: FunctionType::Function,
+            inputs: args
+                .iter()
+                .map(|arg| func_def_arg(type_defs, &arg.node))
+                .collect::<Result<Vec<Input>, CompileError>>()?,
+            outputs,
+        }));
+    }
+
+    Err(CompileError::static_str(
+        "Function definition translation requires FuncDef parameter.",
+    ))
+}
+
+fn func_def_arg<'a>(
+    type_defs: &'a TypeDefs<'a>,
+    arg: &'a vyp::FuncDefArg<'a>,
+) -> Result<Input, CompileError> {
+    Ok(Input {
+        name: String::from(arg.name.node),
+        typ: type_desc(&type_defs, &arg.typ.node)?,
+    })
+}
+
+fn type_desc<'a>(
+    type_defs: &'a TypeDefs<'a>,
+    typ: &'a vyp::TypeDesc<'a>,
+) -> Result<VariableType, CompileError> {
+    if let vyp::TypeDesc::Base { base } = typ {
+        if let Some(custom_type) = type_defs.get(base) {
+            return type_desc(&HashMap::new(), custom_type);
+        }
+    }
+
+    match typ {
+        vyp::TypeDesc::Base { base: "u256" } => Ok(VariableType::Uint256),
+        _ => Err(CompileError::static_str("Unrecognized Vyper type.")),
+    }
+}
+
+#[test]
+fn test_function_serialize() {
+    let func = Function {
+        name: String::from("foobar"),
+        typ: FunctionType::Function,
+        inputs: vec![Input {
+            name: String::from("foo"),
+            typ: VariableType::Uint256,
+        }],
+        outputs: vec![Output {
+            name: String::from("bar"),
+            typ: VariableType::Uint256,
+        }],
+    };
+
+    let json = serde_json::to_string(&func).unwrap();
+
+    assert_eq!(
+        json,
+        r#"{"name":"foobar","type":"function","inputs":[{"name":"foo","type":"uint256"}],"outputs":[{"name":"bar","type":"uint256"}]}"#,
+        "Serialized function not correct."
+    )
+}

--- a/compiler/src/abi/json_builder.rs
+++ b/compiler/src/abi/json_builder.rs
@@ -184,10 +184,12 @@ pub fn type_desc<'a>(
 
 #[cfg(test)]
 mod tests {
-    use crate::abi::json_builder::{Function, FunctionType, Input, VariableType, Output, type_desc, func_def};
-    use vyper_parser::parsers;
-    use vyper_parser::ast as vyp;
+    use crate::abi::json_builder::{
+        func_def, type_desc, Function, FunctionType, Input, Output, VariableType,
+    };
     use std::collections::HashMap;
+    use vyper_parser::ast as vyp;
+    use vyper_parser::parsers;
 
     #[test]
     fn test_type_desc_custom() {
@@ -202,15 +204,22 @@ mod tests {
 
     #[test]
     fn test_func_def() {
-        let toks = vyper_parser::get_parse_tokens("pub def foo(x: u256) -> u256:\n   return x").unwrap();
+        let toks =
+            vyper_parser::get_parse_tokens("pub def foo(x: u256) -> u256:\n   return x").unwrap();
         let vyp_func_def = parsers::func_def(&toks[..]).unwrap().1.node;
 
         let function = func_def(&HashMap::new(), &vyp_func_def).unwrap().unwrap();
         let expected = Function {
             name: String::from("foo"),
             typ: FunctionType::Function,
-            inputs: vec![Input { name: String::from("x"), typ: VariableType::Uint256 }],
-            outputs: vec![Output { name: String::from("return_value"), typ: VariableType::Uint256 }]
+            inputs: vec![Input {
+                name: String::from("x"),
+                typ: VariableType::Uint256,
+            }],
+            outputs: vec![Output {
+                name: String::from("return_value"),
+                typ: VariableType::Uint256,
+            }],
         };
         assert_eq!(function, expected, "Incorrect function");
     }

--- a/compiler/src/abi/json_builder.rs
+++ b/compiler/src/abi/json_builder.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use vyper_parser::ast as vyp;
 
 /// Used to keep track of custom types defined in a module.
-type TypeDefs<'a> = HashMap<&'a str, &'a vyp::TypeDesc<'a>>;
+pub type TypeDefs<'a> = HashMap<&'a str, &'a vyp::TypeDesc<'a>>;
 
 /// TODO: Add support for events.
 #[derive(Serialize, Debug, PartialEq)]

--- a/compiler/src/abi/mod.rs
+++ b/compiler/src/abi/mod.rs
@@ -1,0 +1,1 @@
+pub mod json;

--- a/compiler/src/abi/mod.rs
+++ b/compiler/src/abi/mod.rs
@@ -1,7 +1,10 @@
 use crate::errors::CompileError;
 use vyper_parser as parser;
+use vyper_parser::ast as vyp;
 
 mod json_builder;
+
+pub use json_builder::TypeDefs;
 
 /// Builds a JSON ABI from the source file.
 ///
@@ -20,4 +23,9 @@ pub fn build(src: &str) -> Result<String, CompileError> {
     Err(CompileError::static_str(
         "No contract statements in source.",
     ))
+}
+
+pub fn build_contract<'a>(type_defs: &'a TypeDefs<'a>, stmt: &'a vyp::ModuleStmt<'a>) -> Result<String, CompileError>{
+    let contract = json_builder::contract_def(type_defs, stmt)?;
+    Ok(serde_json::to_string(&contract.functions)?)
 }

--- a/compiler/src/abi/mod.rs
+++ b/compiler/src/abi/mod.rs
@@ -1,1 +1,23 @@
-pub mod json;
+use crate::errors::CompileError;
+use vyper_parser as parser;
+
+mod json_builder;
+
+/// Builds a JSON ABI from the source file.
+///
+/// This API should be rethought as it only provides the ABI for the first contract in the
+/// source file. See: https://github.com/ethereum/rust-vyper/issues/12
+/// TODO: Improve the JSON ABI builder API.
+pub fn build(src: &str) -> Result<String, CompileError> {
+    let tokens = parser::get_parse_tokens(src).unwrap();
+    let vyp_module = parser::parsers::file_input(&tokens[..]).unwrap().1.node;
+    let contracts = json_builder::module(&vyp_module)?;
+
+    if let Some(contract) = contracts.get(0) {
+        return Ok(serde_json::to_string(&contract.functions)?);
+    }
+
+    Err(CompileError::static_str(
+        "No contract statements in source.",
+    ))
+}

--- a/compiler/src/errors.rs
+++ b/compiler/src/errors.rs
@@ -1,0 +1,49 @@
+use vyper_parser::errors::ParseError;
+use vyper_parser::tokenizer::TokenizeError;
+
+#[derive(Debug)]
+pub enum ErrorKind {
+    StaticStr(&'static str),
+    Str(String),
+}
+
+#[derive(Debug)]
+pub struct CompileError {
+    errors: Vec<ErrorKind>,
+}
+
+impl CompileError {
+    pub fn new() -> Self {
+        Self { errors: Vec::new() }
+    }
+
+    pub fn static_str(s: &'static str) -> Self {
+        Self {
+            errors: vec![ErrorKind::StaticStr(s)],
+        }
+    }
+
+    pub fn str(s: String) -> Self {
+        Self {
+            errors: vec![ErrorKind::Str(s)],
+        }
+    }
+}
+
+impl<'a> From<ParseError<'a>> for CompileError {
+    fn from(_: ParseError<'a>) -> Self {
+        CompileError::static_str("Parser error")
+    }
+}
+
+impl<'a> From<TokenizeError> for CompileError {
+    fn from(_: TokenizeError) -> Self {
+        CompileError::static_str("Tokenize error")
+    }
+}
+
+impl<'a> From<serde_json::error::Error> for CompileError {
+    fn from(_: serde_json::error::Error) -> Self {
+        CompileError::static_str("JSON serialization error")
+    }
+}

--- a/compiler/src/errors.rs
+++ b/compiler/src/errors.rs
@@ -47,3 +47,9 @@ impl<'a> From<serde_json::error::Error> for CompileError {
         CompileError::static_str("JSON serialization error")
     }
 }
+
+impl<'a> From<ethabi::Error> for CompileError {
+    fn from(_: ethabi::Error) -> Self {
+        CompileError::static_str("Ethabi error")
+    }
+}

--- a/compiler/src/evm/mod.rs
+++ b/compiler/src/evm/mod.rs
@@ -1,0 +1,39 @@
+use crate::errors::CompileError;
+use crate::yul;
+use serde_json;
+use solc;
+
+/// Compiles Yul source code into bytecode
+pub fn compile(src: &str) -> Result<String, CompileError> {
+    let solc_temp = include_str!("solc_temp.json");
+    let yul_src = yul::compile(src)?.replace("\"", "\\\"");
+    let input = solc_temp.replace("{src}", &yul_src);
+
+    let raw_output = solc::compile(&input);
+    let output: serde_json::Value = serde_json::from_str(&raw_output)?;
+
+    let bytecode = output["contracts"]["input.yul"]["Contract"]["evm"]["bytecode"]["object"]
+        .to_string()
+        .replace("\"", "");
+    if bytecode == "null" {
+        return Err(CompileError::str(output.to_string()));
+    }
+
+    Ok(bytecode)
+}
+
+#[test]
+fn test_solc_sanity() {
+    let yul_src = "{ sstore(0,0) }";
+    let solc_temp = include_str!("solc_temp.json");
+    let input = solc_temp.replace("{src}", &yul_src);
+
+    let raw_output = solc::compile(&input);
+    let output: serde_json::Value = serde_json::from_str(&raw_output).unwrap();
+    
+    let bytecode = output["contracts"]["input.yul"]["object"]["evm"]["bytecode"]["object"]
+        .to_string()
+        .replace("\"", "");
+
+    assert_eq!(bytecode, "6000600055", "incorrect bytecode",);
+}

--- a/compiler/src/evm/mod.rs
+++ b/compiler/src/evm/mod.rs
@@ -30,7 +30,7 @@ fn test_solc_sanity() {
 
     let raw_output = solc::compile(&input);
     let output: serde_json::Value = serde_json::from_str(&raw_output).unwrap();
-    
+
     let bytecode = output["contracts"]["input.yul"]["object"]["evm"]["bytecode"]["object"]
         .to_string()
         .replace("\"", "");

--- a/compiler/src/evm/solc_temp.json
+++ b/compiler/src/evm/solc_temp.json
@@ -1,0 +1,7 @@
+{
+  "language": "Yul",
+  "sources": { "input.yul": { "content": "{src}" } },
+  "settings": {
+    "outputSelection": { "*": { "*": ["*"], "": [ "*" ] } }
+  }
+}

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod abi;
 pub mod errors;
+pub mod evm;
 pub mod yul;

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod abi;
 pub mod errors;
+pub mod yul;

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod abi;
+pub mod errors;

--- a/compiler/src/yul/ast_builder.rs
+++ b/compiler/src/yul/ast_builder.rs
@@ -1,0 +1,307 @@
+use crate::errors::CompileError;
+use crate::yul::{base, constructor, selectors};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+use vyper_parser::ast as vyp;
+use yultsur::yul;
+
+pub type Shared<T> = Rc<RefCell<T>>;
+
+#[allow(dead_code)]
+pub struct ModuleScope<'a> {
+    type_defs: HashMap<&'a str, &'a vyp::TypeDesc<'a>>,
+}
+
+#[allow(dead_code)]
+pub struct ContractScope<'a> {
+    parent: Shared<ModuleScope<'a>>,
+}
+
+#[allow(dead_code)]
+pub struct FunctionScope<'a> {
+    parent: Shared<ContractScope<'a>>,
+}
+
+#[allow(dead_code)]
+pub enum Scope<'a> {
+    Module(Shared<ModuleScope<'a>>),
+    Contract(Shared<ContractScope<'a>>),
+    Function(Shared<FunctionScope<'a>>),
+}
+
+impl<'a> ModuleScope<'a> {
+    fn new() -> Shared<Self> {
+        Rc::new(RefCell::new(ModuleScope {
+            type_defs: HashMap::new(),
+        }))
+    }
+}
+
+impl<'a> ContractScope<'a> {
+    fn new(parent: Shared<ModuleScope<'a>>) -> Shared<Self> {
+        Rc::new(RefCell::new(ContractScope { parent }))
+    }
+}
+
+impl<'a> FunctionScope<'a> {
+    fn new(parent: Shared<ContractScope<'a>>) -> Shared<Self> {
+        Rc::new(RefCell::new(FunctionScope { parent }))
+    }
+}
+
+/// Builds a vector of Yul contracts from a Vyper module.
+pub fn module<'a>(module: &'a vyp::Module<'a>) -> Result<Vec<yul::Object>, CompileError> {
+    let scope = ModuleScope::new();
+
+    Ok(module
+        .body
+        .iter()
+        .map(|stmt| module_stmt(Rc::clone(&scope), &stmt.node))
+        .collect::<Result<Vec<Option<yul::Statement>>, CompileError>>()?
+        .into_iter()
+        .filter_map(|statement| {
+            if let Some(yul::Statement::Object(object)) = statement {
+                return Some(object);
+            }
+
+            None
+        })
+        .collect::<Vec<yul::Object>>())
+}
+
+/// Builds a Yul statement from a Vyper module statement.
+pub fn module_stmt<'a>(
+    scope: Shared<ModuleScope<'a>>,
+    stmt: &'a vyp::ModuleStmt<'a>,
+) -> Result<Option<yul::Statement>, CompileError> {
+    match stmt {
+        vyp::ModuleStmt::TypeDef { .. } => {
+            type_def(scope, stmt)?;
+            Ok(None)
+        }
+        vyp::ModuleStmt::ContractDef { .. } => {
+            contract_def(scope, stmt).map(|object| Some(yul::Statement::Object(object)))
+        }
+        _ => Err(CompileError::static_str(
+            "Unable to translate module statement.",
+        )),
+    }
+}
+
+/// Builds a Yul object from a Vyper contract.
+pub fn contract_def<'a>(
+    scope: Shared<ModuleScope<'a>>,
+    stmt: &'a vyp::ModuleStmt<'a>,
+) -> Result<yul::Object, CompileError> {
+    let new_scope = ContractScope::new(scope);
+
+    if let vyp::ModuleStmt::ContractDef { name: _, body } = stmt {
+        let mut statements = body
+            .iter()
+            .map(|stmt| contract_stmt(Rc::clone(&new_scope), &stmt.node))
+            .collect::<Result<Vec<yul::Statement>, CompileError>>()?;
+
+        // TODO: Use functions from actual contract ABI once the builder is merged.
+        statements.push(yul::Statement::Switch(selectors::switch(vec![])?));
+
+        return Ok(yul::Object {
+            name: base::untyped_identifier("Contract"),
+            code: constructor::code(),
+            objects: vec![yul::Object {
+                name: base::untyped_identifier("runtime"),
+                code: yul::Code {
+                    block: yul::Block { statements },
+                },
+                objects: vec![],
+            }],
+        });
+    }
+
+    Err(CompileError::static_str(
+        "Contract definition translation requires ContractDef.",
+    ))
+}
+
+/// Builds a Yul statement from a Vyper contract statement.
+pub fn contract_stmt<'a>(
+    scope: Shared<ContractScope<'a>>,
+    stmt: &'a vyp::ContractStmt<'a>,
+) -> Result<yul::Statement, CompileError> {
+    match stmt {
+        vyp::ContractStmt::FuncDef { .. } => {
+            func_def(scope, stmt).map(|definition| yul::Statement::FunctionDefinition(definition))
+        }
+        _ => Err(CompileError::static_str(
+            "Unable to translate module statement.",
+        )),
+    }
+}
+
+/// Adds the custom type def to the module scope.
+fn type_def<'a>(
+    scope: Shared<ModuleScope<'a>>,
+    stmt: &'a vyp::ModuleStmt<'a>,
+) -> Result<(), CompileError> {
+    if let vyp::ModuleStmt::TypeDef { name, typ } = stmt {
+        scope.borrow_mut().type_defs.insert(name.node, &typ.node);
+        return Ok(());
+    }
+
+    Err(CompileError::static_str(
+        "Type definition translation requires TypeDef.",
+    ))
+}
+
+/// Builds a Yul function definition from a Vyper function definition.
+pub fn func_def<'a>(
+    scope: Shared<ContractScope<'a>>,
+    stmt: &'a vyp::ContractStmt<'a>,
+) -> Result<yul::FunctionDefinition, CompileError> {
+    if let vyp::ContractStmt::FuncDef {
+        qual: _,
+        name,
+        args,
+        return_type,
+        body,
+    } = stmt
+    {
+        let new_scope = FunctionScope::new(scope);
+
+        let parameters = args
+            .iter()
+            .map(|arg| func_def_arg(Rc::clone(&new_scope), &arg.node))
+            .collect::<Result<Vec<yul::Identifier>, CompileError>>()?;
+
+        let returns = if return_type.is_some() {
+            vec![base::untyped_identifier("return_val")]
+        } else {
+            Vec::new()
+        };
+
+        let statements: Vec<yul::Statement> = body
+            .iter()
+            .map(|stmt| func_stmt(Rc::clone(&new_scope), &stmt.node))
+            .collect::<Result<Vec<yul::Statement>, CompileError>>()?;
+
+        return Ok(yul::FunctionDefinition {
+            name: base::untyped_identifier(name.node),
+            parameters,
+            returns,
+            block: yul::Block { statements },
+        });
+    }
+
+    Err(CompileError::static_str(
+        "Function definition translation requires FuncDef.",
+    ))
+}
+
+/// Builds a Yul identifier from a Vyper function argument.
+pub fn func_def_arg<'a>(
+    _scope: Shared<FunctionScope<'a>>,
+    arg: &'a vyp::FuncDefArg<'a>,
+) -> Result<yul::Identifier, CompileError> {
+    Ok(base::untyped_identifier(arg.name.node))
+}
+
+/// Builds a Yul statement from a function statement.
+pub fn func_stmt<'a>(
+    scope: Shared<FunctionScope<'a>>,
+    stmt: &'a vyp::FuncStmt<'a>,
+) -> Result<yul::Statement, CompileError> {
+    match stmt {
+        vyp::FuncStmt::Return { .. } => func_return(scope, stmt),
+        _ => Err(CompileError::static_str(
+            "Unable to translate function statement",
+        )),
+    }
+}
+
+/// Builds a Yul return statement from a Vyper return statement.
+fn func_return<'a>(
+    scope: Shared<FunctionScope<'a>>,
+    stmt: &'a vyp::FuncStmt<'a>,
+) -> Result<yul::Statement, CompileError> {
+    if let vyp::FuncStmt::Return { value: Some(value) } = stmt {
+        let return_value = expr(scope, &value.node)?;
+
+        return Ok(yul::Statement::Assignment(yul::Assignment {
+            identifiers: vec![base::untyped_identifier("return_val")],
+            expression: return_value,
+        }));
+    }
+
+    Err(CompileError::static_str(
+        "Function return translation requires Return parameter.",
+    ))
+}
+
+/// Builds a Yul expression from a Vyper expression.
+fn expr<'a>(
+    _scope: Shared<FunctionScope<'a>>,
+    expr: &'a vyp::Expr<'a>,
+) -> Result<yul::Expression, CompileError> {
+    match expr {
+        vyp::Expr::Name(name) => Ok(base::untyped_literal_expr(name)),
+        _ => Err(CompileError::static_str("Unable to translate expression")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::yul::ast_builder::{contract_def, func_def, type_def, ContractScope, ModuleScope};
+    use std::rc::Rc;
+    use vyper_parser::ast::TypeDesc;
+    use vyper_parser::parsers;
+
+    #[test]
+    fn test_compile_type_def() {
+        let src = "type Foo = u256";
+        let toks = vyper_parser::get_parse_tokens(src).unwrap();
+        let stmt = parsers::type_def(&toks[..]).unwrap().1.node;
+        let scope = ModuleScope::new();
+
+        type_def(Rc::clone(&scope), &stmt).expect("Unable to handle type def");
+
+        assert_eq!(
+            scope.borrow().type_defs["Foo"],
+            &TypeDesc::Base { base: "u256" },
+            "Compilation of type definition failed."
+        );
+    }
+
+    #[test]
+    fn test_compile_func_def() {
+        let src = "def foo(x: u256) -> u256:\n   return x";
+        let toks = vyper_parser::get_parse_tokens(src).unwrap();
+        let stmt = parsers::func_def(&toks[..]).unwrap().1.node;
+        let scope = ContractScope::new(ModuleScope::new());
+
+        let result = func_def(Rc::clone(&scope), &stmt).expect("Unable to build func def");
+
+        assert_eq!(
+            result.to_string(),
+            "function foo(x) -> return_val { return_val := x }",
+            "Compilation of function definition failed."
+        );
+    }
+
+    #[test]
+    fn test_contract_def() {
+        let src = "contract Foo:\
+                   \n  pub def bar(x: u256) -> u256:\
+                   \n    return x";
+        let toks = vyper_parser::get_parse_tokens(src).unwrap();
+        let stmt = parsers::contract_def(&toks[..]).unwrap().1.node;
+        let scope = ModuleScope::new();
+
+        let result = contract_def(scope, &stmt).expect("Unable to handle contract def");
+
+        assert_eq!(
+            result.to_string(),
+            r#"object "Contract" { code { let size := datasize("runtime") datacopy(0, dataoffset("runtime"), size) return(0, size) } object "runtime" { code { function bar(x) -> return_val { return_val := x } switch shr(224, calldataload(0))  }  } }"#,
+            "Compilation of contract definition failed."
+        );
+    }
+}

--- a/compiler/src/yul/base.rs
+++ b/compiler/src/yul/base.rs
@@ -1,0 +1,23 @@
+use yultsur::yul;
+
+pub fn untyped_identifier_expr(i: &str) -> yul::Expression {
+    yul::Expression::Identifier(untyped_identifier(i))
+}
+
+pub fn untyped_identifier(i: &str) -> yul::Identifier {
+    yul::Identifier {
+        identifier: String::from(i),
+        yultype: None,
+    }
+}
+
+pub fn untyped_literal_expr(l: &str) -> yul::Expression {
+    yul::Expression::Literal(untyped_literal(l))
+}
+
+pub fn untyped_literal(l: &str) -> yul::Literal {
+    yul::Literal {
+        literal: String::from(l),
+        yultype: None,
+    }
+}

--- a/compiler/src/yul/constructor.rs
+++ b/compiler/src/yul/constructor.rs
@@ -1,0 +1,48 @@
+use crate::yul::base;
+use yultsur::yul;
+
+/// Builds a code block that returns the runtime object.
+///
+/// TODO: Add real constructor code here.
+pub fn code() -> yul::Code {
+    yul::Code {
+        block: yul::Block {
+            statements: vec![
+                yul::Statement::VariableDeclaration(yul::VariableDeclaration {
+                    identifiers: vec![base::untyped_identifier("size")],
+                    expression: Some(yul::Expression::FunctionCall(yul::FunctionCall {
+                        identifier: base::untyped_identifier("datasize"),
+                        arguments: vec![base::untyped_identifier_expr(r#""runtime""#)],
+                    })),
+                }),
+                yul::Statement::Expression(yul::Expression::FunctionCall(yul::FunctionCall {
+                    identifier: base::untyped_identifier("datacopy"),
+                    arguments: vec![
+                        base::untyped_literal_expr("0"),
+                        yul::Expression::FunctionCall(yul::FunctionCall {
+                            identifier: base::untyped_identifier("dataoffset"),
+                            arguments: vec![base::untyped_literal_expr(r#""runtime""#)],
+                        }),
+                        base::untyped_identifier_expr("size"),
+                    ],
+                })),
+                yul::Statement::Expression(yul::Expression::FunctionCall(yul::FunctionCall {
+                    identifier: base::untyped_identifier("return"),
+                    arguments: vec![
+                        base::untyped_literal_expr("0"),
+                        base::untyped_identifier_expr("size"),
+                    ],
+                })),
+            ],
+        },
+    }
+}
+
+#[test]
+fn test_constructor() {
+    assert_eq!(
+        code().to_string(),
+        r#"code { let size := datasize("runtime") datacopy(0, dataoffset("runtime"), size) return(0, size) }"#,
+        "incorrect constructor"
+    )
+}

--- a/compiler/src/yul/mod.rs
+++ b/compiler/src/yul/mod.rs
@@ -1,0 +1,20 @@
+use crate::errors::CompileError;
+use vyper_parser as parser;
+
+mod ast_builder;
+mod base;
+mod constructor;
+mod selectors;
+
+/// Builds Yul code from Vyper source.
+pub fn compile(src: &str) -> Result<String, CompileError> {
+    let tokens = parser::get_parse_tokens(src)?;
+    let vyp_module = parser::parsers::file_input(&tokens[..])?.1.node;
+
+    // TODO: Handle multiple contracts in one Vyper module cleanly.
+    if let Some(first_contract) = ast_builder::module(&vyp_module)?.get(0) {
+        return Ok(first_contract.to_string());
+    }
+
+    Err(CompileError::static_str("Unable to parse tokens."))
+}

--- a/compiler/src/yul/selectors.rs
+++ b/compiler/src/yul/selectors.rs
@@ -1,0 +1,175 @@
+use crate::errors::CompileError;
+use crate::yul::base;
+use tiny_keccak::{Hasher, Keccak};
+use yultsur::yul;
+
+/// Builds a switch statement from the contract ABI.
+/// The switch's expression is the 4 left-most bytes in the calldata and each case is
+/// defined as the keccak value of each function's signature (without return data).
+pub fn switch(functions: Vec<&ethabi::Function>) -> Result<yul::Switch, CompileError> {
+    let cases = functions
+        .into_iter()
+        .map(|function| case(function))
+        .collect::<Result<Vec<yul::Case>, CompileError>>()?;
+
+    Ok(yul::Switch {
+        expression: expression(),
+        cases,
+    })
+}
+
+/// Builds an expression that loads the first 4 bytes of the calldata.
+pub fn expression() -> yul::Expression {
+    yul::Expression::FunctionCall(yul::FunctionCall {
+        identifier: base::untyped_identifier("shr"),
+        arguments: vec![
+            base::untyped_literal_expr("224"),
+            yul::Expression::FunctionCall(yul::FunctionCall {
+                identifier: base::untyped_identifier("calldataload"),
+                arguments: vec![base::untyped_literal_expr("0")],
+            }),
+        ],
+    })
+}
+
+/// Builds a switch case from the function. It matches the selector and calls
+/// the function as described in the ABI. The value (if any) returned by the
+/// function is stored in memory and returned by the contract.
+///
+/// Currently, this assumes each input and the single output is 256 bits.
+/// TODO: Handle types of different sizes: https://solidity.readthedocs.io/en/v0.6.2/abi-spec.html#types
+pub fn case(function: &ethabi::Function) -> Result<yul::Case, CompileError> {
+    let selector = Some(selector_literal(function.signature()));
+
+    if function.outputs.is_empty() {
+        return Ok(yul::Case {
+            literal: selector,
+            block: yul::Block {
+                statements: vec![yul::Statement::Expression(yul::Expression::FunctionCall(
+                    yul::FunctionCall {
+                        identifier: base::untyped_identifier("foo"),
+                        arguments: vec![],
+                    },
+                ))],
+            },
+        });
+    }
+
+    Ok(yul::Case {
+        literal: selector,
+        block: yul::Block {
+            statements: vec![
+                yul::Statement::Expression(yul::Expression::FunctionCall(yul::FunctionCall {
+                    identifier: base::untyped_identifier("mstore"),
+                    arguments: vec![
+                        base::untyped_literal_expr("0"),
+                        yul::Expression::FunctionCall(yul::FunctionCall {
+                            identifier: base::untyped_identifier(&function.name),
+                            arguments: (0..function.inputs.len())
+                                .map(|n| {
+                                    base::untyped_literal_expr(
+                                        format!("calldataload({})", n * 32 + 4).as_ref(),
+                                    )
+                                })
+                                .collect(),
+                        }),
+                    ],
+                })),
+                yul::Statement::Expression(yul::Expression::FunctionCall(yul::FunctionCall {
+                    identifier: base::untyped_identifier("return"),
+                    arguments: vec![
+                        base::untyped_literal_expr("0"),
+                        base::untyped_literal_expr("32"),
+                    ],
+                })),
+            ],
+        },
+    })
+}
+
+/// Computes the keccak-256 value of the input portion of the function signature and returns the
+/// first 4 bytes.
+///
+/// Example: "foo(uint256):(uint256)" => keccak256("foo(uint256)")
+pub fn selector_literal(sig: String) -> yul::Literal {
+    let mut sig_halves = sig.split(":");
+
+    let mut keccak = Keccak::v256();
+    let mut selector = [0u8; 4];
+
+    if let Some(first_half) = sig_halves.next() {
+        keccak.update(first_half.as_bytes());
+        keccak.finalize(&mut selector);
+    }
+
+    base::untyped_literal(&format!("0x{}", hex::encode(selector)))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::yul::selectors::{case, expression, selector_literal, switch};
+    use stringreader::StringReader;
+
+    #[test]
+    fn test_expression() {
+        assert_eq!(
+            expression().to_string(),
+            "shr(224, calldataload(0))",
+            "Switch expression not correct."
+        )
+    }
+
+    #[test]
+    fn test_selector_literal_basic() {
+        let json_abi = r#"[{"name": "foo", "type": "function", "inputs": [], "outputs": []}]"#;
+        let abi = ethabi::Contract::load(StringReader::new(json_abi)).expect("Unable to load abi.");
+        let ref foo = abi.functions["foo"][0];
+
+        assert_eq!(
+            selector_literal(foo.signature()).to_string(),
+            String::from("0xc2985578"),
+            "Incorrect selector"
+        )
+    }
+
+    #[test]
+    fn test_selector_literal() {
+        let json_abi = r#"[{"name": "foo", "type": "function", "inputs": [{ "name": "bar", "type": "uint256" }], "outputs": []}]"#;
+        let abi = ethabi::Contract::load(StringReader::new(json_abi)).expect("Unable to load abi.");
+        let ref foo = abi.functions["foo"][0];
+
+        assert_eq!(
+            selector_literal(foo.signature()).to_string(),
+            String::from("0x2fbebd38"),
+            "Incorrect selector"
+        )
+    }
+
+    #[test]
+    fn test_case() {
+        let json_abi = r#"[{"name": "foo", "type": "function", "inputs": [{ "name": "bar", "type": "uint256" }], "outputs": [{ "name": "baz", "type": "uint256" }]}]"#;
+        let abi = ethabi::Contract::load(StringReader::new(json_abi)).expect("Unable to load abi.");
+        let ref foo = abi.functions["foo"][0];
+
+        assert_eq!(
+            case(foo).expect("Unable to build case.").to_string(),
+            String::from("case 0x2fbebd38 { mstore(0, foo(calldataload(4))) return(0, 32) }"),
+            "Incorrect case"
+        );
+    }
+
+    #[test]
+    fn test_switch_basic() {
+        let json_abi = r#"[{"name": "foo", "type": "function", "inputs": [], "outputs": []}]"#;
+        let abi = ethabi::Contract::load(StringReader::new(json_abi)).expect("Unable to load abi.");
+        let functions = abi.functions().collect();
+
+        assert_eq!(
+            switch(functions)
+                .expect("Unable to build selector")
+                .to_string(),
+            String::from("switch shr(224, calldataload(0)) case 0xc2985578 { foo() } "),
+            "Incorrect selector"
+        )
+    }
+}

--- a/compiler/tests/fixtures/guest_book.vy
+++ b/compiler/tests/fixtures/guest_book.vy
@@ -1,0 +1,15 @@
+type BookMsg = bytes[100]
+
+contract GuestBook:
+    pub guest_book: map<address, BookMsg>
+
+    event Signed:
+        idx book_msg: BookMsg
+
+    pub def sign(book_msg: BookMsg):
+        self.guest_book[msg.sender] = book_msg
+
+        emit Signed(book_msg=book_msg)
+
+    pub def get_msg(addr: address) -> BookMsg:
+        return self.guest_book[addr]

--- a/compiler/tests/fixtures/simple_contract.vy
+++ b/compiler/tests/fixtures/simple_contract.vy
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: u256) -> u256:
+        return x

--- a/compiler/tests/fixtures/simple_map.vy
+++ b/compiler/tests/fixtures/simple_map.vy
@@ -1,0 +1,9 @@
+contract Foo:
+    pub bar: map<u256, u256>
+
+    pub def read_bar(key: u256) -> u256:
+        return bar[key]
+
+    pub def write_bar(key: u256, value: u256) -> u256:
+        bar[key] = value
+

--- a/compiler/tests/test_evm.rs
+++ b/compiler/tests/test_evm.rs
@@ -1,0 +1,107 @@
+use ethabi;
+use evm;
+use evm_runtime::Handler;
+use primitive_types;
+use std::collections::BTreeMap;
+use std::fs;
+use stringreader::StringReader;
+use vyper_compiler as compiler;
+
+type Executor<'a> = evm::executor::StackExecutor<'a, 'a, evm::backend::MemoryBackend<'a>>;
+
+fn with_executor(test: &dyn Fn(Executor)) {
+    let vicinity = evm::backend::MemoryVicinity {
+        gas_price: u256("0"),
+        origin: h160(5),
+        chain_id: u256("0"),
+        block_hashes: Vec::new(),
+        block_number: u256("0"),
+        block_coinbase: h160(5),
+        block_timestamp: u256("0"),
+        block_difficulty: u256("0"),
+        block_gas_limit: primitive_types::U256::MAX,
+    };
+    let state: BTreeMap<primitive_types::H160, evm::backend::MemoryAccount> = BTreeMap::new();
+    let config = evm::Config::istanbul();
+
+    let backend = evm::backend::MemoryBackend::new(&vicinity, state);
+    let executor = evm::executor::StackExecutor::new(&backend, usize::max_value(), &config);
+
+    test(executor);
+}
+
+fn compile_fixture(name: &str) -> (String, String) {
+    let src = fs::read_to_string(format!("tests/fixtures/{}", name))
+        .expect("Unable to read fixture file.");
+    (
+        compiler::evm::compile(&src).expect("Unable to compile to bytecode."),
+        compiler::abi::build(&src).expect("Unable to build ABI."),
+    )
+}
+
+fn u256(n: &str) -> primitive_types::U256 {
+    primitive_types::U256::from_dec_str(n).unwrap()
+}
+
+fn h160(b: u8) -> primitive_types::H160 {
+    primitive_types::H160::repeat_byte(b)
+}
+
+fn u256_abi_token(n: &str) -> ethabi::Token {
+    ethabi::Token::Uint(ethabi::Uint::from(u256(n)))
+}
+
+#[test]
+fn test_evm_sanity() {
+    with_executor(&|mut executor| {
+        let address = h160(4);
+        let amount = u256("1000");
+
+        executor.deposit(address, amount);
+        assert_eq!(executor.balance(address), amount);
+    })
+}
+
+#[test]
+fn test_simple_contract() {
+    with_executor(&|mut executor| {
+        let caller_address = h160(4);
+        let (bytecode, abi) = compile_fixture("simple_contract.vy");
+
+        if let evm::Capture::Exit(exit) = executor.create(
+            caller_address,
+            evm_runtime::CreateScheme::Dynamic,
+            u256("0"),
+            hex::decode(bytecode).unwrap(),
+            None,
+        ) {
+            let code_address = exit.1.expect("No contract address.");
+            let context = evm::Context {
+                address: caller_address,
+                caller: caller_address,
+                apparent_value: u256("0"),
+            };
+            let contract_abi =
+                ethabi::Contract::load(StringReader::new(&abi)).expect("Unable to load ABI.");
+            let bar = &contract_abi.functions["bar"][0];
+
+            let params = [u256_abi_token("100")];
+            let input = bar.encode_input(&params).unwrap();
+
+            if let evm::Capture::Exit(exit) =
+                executor.call(code_address, None, input, None, false, context)
+            {
+                let output = bar
+                    .decode_output(&exit.1)
+                    .expect("Unable to decode output.");
+                assert_eq!(
+                    output[0],
+                    u256_abi_token("100"),
+                    "bar output does not match."
+                )
+            }
+        } else {
+            panic!("Failed to create contract.")
+        }
+    })
+}


### PR DESCRIPTION
Part of #10.

*It's probably best to review this after #15 and #16 get merged, since those are included.*

This includes an `evm` module which uses the solc Rust bindings to compile Yul into bytecode. It also has a test that deploys a simple contract onto the EVM and interacts with it using the ABI produced by the `abi` module.